### PR TITLE
Fix minor formatting glitch in how usernames are displayed

### DIFF
--- a/app/src/main/java/com/github/oryanmat/trellowidget/model/User.java
+++ b/app/src/main/java/com/github/oryanmat/trellowidget/model/User.java
@@ -7,6 +7,6 @@ public class User {
 
     @Override
     public String toString() {
-        return fullName + "@" + username;
+        return fullName + " (@" + username + ")";
     }
 }


### PR DESCRIPTION
I was bothered by the missing space in "Signed in as Jim Ramsay@jimramsay"
and changed this to "Signed in as Jim Ramsay (@jimramsay)"

Signed-off-by: Jim Ramsay i.am@jimramsay.com
