### PR TITLE
Ensure badges align better with text for smaller font sizes

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -18,6 +18,7 @@
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:text">@string/zero</item>
+        <item name="android:layout_gravity">center_vertical</item>
     </style>
 
     <style name="CardEditText">


### PR DESCRIPTION
Setting all badge images and text to be vertically centered ensures no
matter which is larger (text or image), everything lines up pretty okay.

Signed-off-by: Jim Ramsay i.am@jimramsay.com
