### PR TITLE
Fix StackOverflowError when selecting colors

### DIFF
--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/color/ColorPreference.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/color/ColorPreference.kt
@@ -30,7 +30,7 @@ class ColorPreference @JvmOverloads constructor(
             addOpacityBar(view.opacitybar)
             color = getPersistedInt(DEFAULT_VALUE)
             oldCenterColor = getPersistedInt(DEFAULT_VALUE)
-            onColorChangedListener = ColorPicker.OnColorChangedListener { color = it }
+            onColorChangedListener = ColorPicker.OnColorChangedListener { this@ColorPreference.color = it }
         }
     }
 


### PR DESCRIPTION
The kotlin 'with' overloads the hides the ColorPreference.color we intend
to set in the onColorChangedListener with the view.color_picker.color that
causes this same onColorChangedListener to fire.
