### PR TITLE
Unique title background color

### DIFF
--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/activity/GeneralPreferenceFragment.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/activity/GeneralPreferenceFragment.kt
@@ -26,6 +26,13 @@ class GeneralPreferenceFragment : PreferenceFragment() {
         listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_title_fore_color_key))
         listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_title_use_unique_color_key))
         listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_update_interval_key))
+
+        val titleBgPref = findPreference(getString(R.string.pref_title_back_color_key)) as ColorPreference
+        val cardBgPref = findPreference(getString(R.string.pref_back_color_key)) as ColorPreference
+        titleBgPref.copyFrom = cardBgPref
+        val titleFgPref = findPreference(getString(R.string.pref_title_fore_color_key)) as ColorPreference
+        val cardFgPref = findPreference(getString(R.string.pref_fore_color_key)) as ColorPreference
+        titleFgPref.copyFrom = cardFgPref
     }
 
     override fun onResume() {

--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/activity/GeneralPreferenceFragment.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/activity/GeneralPreferenceFragment.kt
@@ -4,6 +4,7 @@ import android.content.SharedPreferences
 import android.os.Bundle
 import android.preference.ListPreference
 import android.preference.PreferenceFragment
+import android.preference.SwitchPreference
 import com.github.oryanmat.trellowidget.R
 import com.github.oryanmat.trellowidget.util.color.ColorPreference
 import com.github.oryanmat.trellowidget.widget.updateWidgets
@@ -23,6 +24,7 @@ class GeneralPreferenceFragment : PreferenceFragment() {
         listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_fore_color_key))
         listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_title_back_color_key))
         listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_title_fore_color_key))
+        listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_title_use_unique_color_key))
         listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_update_interval_key))
     }
 
@@ -60,6 +62,17 @@ class GeneralPreferenceFragment : PreferenceFragment() {
         } else if (key == getString(R.string.pref_title_fore_color_key)) {
             val preference = findPreference(key) as ColorPreference
             preference.summary = String.format(COLOR_FORMAT, preference.color)
+        } else if (key == getString(R.string.pref_title_use_unique_color_key)) {
+            val preference = findPreference(key) as SwitchPreference
+            with(preference) {
+                setSummary(if (isChecked)
+                    R.string.pref_title_use_unique_color_enabled_desc else
+                    R.string.pref_title_use_unique_color_disabled_desc)
+                val titleFgPref = findPreference(getString(R.string.pref_title_fore_color_key)) as ColorPreference
+                val titleBgPref = findPreference(getString(R.string.pref_title_back_color_key)) as ColorPreference
+                titleFgPref.isEnabled = isChecked
+                titleBgPref.isEnabled = isChecked
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/activity/GeneralPreferenceFragment.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/activity/GeneralPreferenceFragment.kt
@@ -21,6 +21,8 @@ class GeneralPreferenceFragment : PreferenceFragment() {
         listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_text_size_key))
         listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_back_color_key))
         listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_fore_color_key))
+        listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_title_back_color_key))
+        listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_title_fore_color_key))
         listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_update_interval_key))
     }
 
@@ -50,6 +52,12 @@ class GeneralPreferenceFragment : PreferenceFragment() {
             val preference = findPreference(key) as ColorPreference
             preference.summary = String.format(COLOR_FORMAT, preference.color)
         } else if (key == getString(R.string.pref_fore_color_key)) {
+            val preference = findPreference(key) as ColorPreference
+            preference.summary = String.format(COLOR_FORMAT, preference.color)
+        } else if (key == getString(R.string.pref_title_back_color_key)) {
+            val preference = findPreference(key) as ColorPreference
+            preference.summary = String.format(COLOR_FORMAT, preference.color)
+        } else if (key == getString(R.string.pref_title_fore_color_key)) {
             val preference = findPreference(key) as ColorPreference
             preference.summary = String.format(COLOR_FORMAT, preference.color)
         }

--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/PrefUtil.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/PrefUtil.kt
@@ -15,13 +15,21 @@ internal fun Context.getInterval() =
                 getString(R.string.pref_update_interval_key),
                 getString(R.string.pref_update_interval_default)))
 
-internal @ColorInt fun Context.getBackgroundColor() = getColor(
+internal @ColorInt fun Context.getCardBackgroundColor() = getColor(
         getString(R.string.pref_back_color_key),
         resources.getInteger(R.integer.pref_back_color_default))
 
-internal @ColorInt fun Context.getForegroundColor() = getColor(
+internal @ColorInt fun Context.getCardForegroundColor() = getColor(
         getString(R.string.pref_fore_color_key),
         resources.getInteger(R.integer.pref_fore_color_default))
+
+internal @ColorInt fun Context.getTitleBackgroundColor() = getColor(
+        getString(R.string.pref_back_color_key),
+        resources.getInteger(R.integer.pref_title_back_color_default))
+
+internal @ColorInt fun Context.getTitleForegroundColor() = getColor(
+        getString(R.string.pref_fore_color_key),
+        resources.getInteger(R.integer.pref_title_fore_color_default))
 
 private @ColorInt fun Context.getColor(key: String, defValue: Int) =
         sharedPreferences().getInt(key, defValue)

--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/PrefUtil.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/PrefUtil.kt
@@ -23,13 +23,27 @@ internal @ColorInt fun Context.getCardForegroundColor() = getColor(
         getString(R.string.pref_fore_color_key),
         resources.getInteger(R.integer.pref_fore_color_default))
 
-internal @ColorInt fun Context.getTitleBackgroundColor() = getColor(
-        getString(R.string.pref_back_color_key),
-        resources.getInteger(R.integer.pref_title_back_color_default))
+internal fun Context.isTitleUniqueColor() = sharedPreferences().getBoolean(
+        getString(R.string.pref_title_use_unique_color_key),
+        resources.getBoolean(R.bool.pref_title_use_unique_color_default))
 
-internal @ColorInt fun Context.getTitleForegroundColor() = getColor(
-        getString(R.string.pref_fore_color_key),
-        resources.getInteger(R.integer.pref_title_fore_color_default))
+internal @ColorInt fun Context.getTitleBackgroundColor() : Int {
+    return if (isTitleUniqueColor())
+        getColor(
+            getString(R.string.pref_title_back_color_key),
+            resources.getInteger(R.integer.pref_title_back_color_default))
+    else
+        getCardBackgroundColor()
+}
+
+internal @ColorInt fun Context.getTitleForegroundColor() : Int {
+    return if (isTitleUniqueColor())
+        getColor(
+            getString(R.string.pref_title_fore_color_key),
+            resources.getInteger(R.integer.pref_title_fore_color_default))
+    else
+        getCardForegroundColor()
+}
 
 private @ColorInt fun Context.getColor(key: String, defValue: Int) =
         sharedPreferences().getInt(key, defValue)

--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/RemoteViewsUtil.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/RemoteViewsUtil.kt
@@ -50,6 +50,10 @@ object RemoteViewsUtil {
         views.setInt(view, METHOD_SET_ALPHA, alpha(color))
     }
 
+    fun setBackgroundColor(views: RemoteViews, @IdRes view: Int, @ColorInt color: Int) {
+        views.setInt(view, "setBackgroundColor", color)
+    }
+
     fun getScaledValue(context: Context, @DimenRes dimen: Int): Float {
         val dimension = context.resources.getDimension(dimen)
         val density = context.resources.displayMetrics.density

--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/color/ColorPreference.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/color/ColorPreference.kt
@@ -17,7 +17,8 @@ val DEFAULT_VALUE = Color.BLACK
  */
 class ColorPreference @JvmOverloads constructor(
         context: Context, attributeSet: AttributeSet,
-        var color: Int = DEFAULT_VALUE) : DialogPreference(context, attributeSet) {
+        var color: Int = DEFAULT_VALUE,
+        var copyFrom: ColorPreference? = null) : DialogPreference(context, attributeSet) {
 
     init {
         dialogLayoutResource = R.layout.color_chooser
@@ -41,6 +42,17 @@ class ColorPreference @JvmOverloads constructor(
             oldCenterColor = getPersistedInt(DEFAULT_VALUE)
             onColorChangedListener = ColorPicker.OnColorChangedListener { this@ColorPreference.color = it }
             repairSVBar(view, color)
+        }
+        with(view.copyButton) {
+            val copyTarget = copyFrom as? ColorPreference
+            visibility = if (copyTarget != null) View.VISIBLE else View.INVISIBLE
+            if (copyTarget is ColorPreference) {
+                text = context.getString(R.string.pref_title_copy_from_card, copyTarget.title)
+                setOnClickListener {
+                    view.color_picker.color = copyTarget.color
+                    repairSVBar(view, copyTarget.color)
+                }
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/color/ColorUtil.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/color/ColorUtil.kt
@@ -10,3 +10,11 @@ import android.support.annotation.ColorInt
     hsv[2] *= 0.5f
     return Color.HSVToColor(hsv)
 }
+
+@ColorInt fun Int.buttonDim(): Int {
+    val hsv = FloatArray(3)
+    Color.colorToHSV(this, hsv)
+    // 3/4 the value component
+    hsv[2] *= 0.75f
+    return Color.HSVToColor(hsv)
+}

--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/widget/CardRemoteViewFactory.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/widget/CardRemoteViewFactory.kt
@@ -22,7 +22,7 @@ import com.github.oryanmat.trellowidget.util.RemoteViewsUtil.setTextView
 import com.github.oryanmat.trellowidget.util.TrelloAPIUtil
 import com.github.oryanmat.trellowidget.util.color.colors
 import com.github.oryanmat.trellowidget.util.color.dim
-import com.github.oryanmat.trellowidget.util.getForegroundColor
+import com.github.oryanmat.trellowidget.util.getCardForegroundColor
 import com.github.oryanmat.trellowidget.util.getList
 import java.util.*
 
@@ -34,7 +34,7 @@ class CardRemoteViewFactory(private val context: Context,
     override fun onDataSetChanged() {
         var list = context.getList(appWidgetId)
         list = TrelloAPIUtil.instance.getCards(list)
-        color = context.getForegroundColor()
+        color = context.getCardForegroundColor()
 
         if (BoardList.ERROR != list.id) {
             cards = list.cards

--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/widget/TrelloWidgetProvider.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/widget/TrelloWidgetProvider.kt
@@ -15,6 +15,7 @@ import com.github.oryanmat.trellowidget.util.*
 import com.github.oryanmat.trellowidget.util.RemoteViewsUtil.setBackgroundColor
 import com.github.oryanmat.trellowidget.util.RemoteViewsUtil.setImageViewColor
 import com.github.oryanmat.trellowidget.util.RemoteViewsUtil.setTextView
+import com.github.oryanmat.trellowidget.util.color.buttonDim
 
 private val REFRESH_ACTION = "com.github.oryanmat.trellowidget.refreshAction"
 private val WIDGET_ID = "com.github.oryanmat.trellowidget.widgetId"
@@ -38,23 +39,29 @@ class TrelloWidgetProvider : AppWidgetProvider() {
         // TODO: We should update both the BoardList and Board on a refresh
         val list = context.getList(appWidgetId)
         val board = context.getBoard(appWidgetId)
-        @ColorInt val color = context.getForegroundColor()
-        @ColorInt val bgcolor = context.getBackgroundColor()
+        @ColorInt val cardFgColor = context.getCardForegroundColor()
+        @ColorInt val cardBgColor = context.getCardBackgroundColor()
+        @ColorInt val titleFgColor = context.getTitleForegroundColor()
+        @ColorInt val titleBgColor = context.getTitleBackgroundColor()
 
         val views = RemoteViews(context.packageName, R.layout.trello_widget)
-        setTextView(views, R.id.list_title, list.name, color)
+
+        // Set up the title bar
+        setTextView(views, R.id.list_title, list.name, titleFgColor)
+        setImageViewColor(views, R.id.refreshButt, titleFgColor.buttonDim())
+        setImageViewColor(views, R.id.configButt, titleFgColor.buttonDim())
+        setBackgroundColor(views, R.id.title_bar, titleBgColor)
         views.setOnClickPendingIntent(R.id.refreshButt, getRefreshPendingIntent(context, appWidgetId))
         views.setOnClickPendingIntent(R.id.configButt, getReconfigPendingIntent(context, appWidgetId))
         views.setOnClickPendingIntent(R.id.list_title, getTitleIntent(context, board))
-        views.setPendingIntentTemplate(R.id.card_list, getCardPendingIntent(context))
-        setImageViewColor(views, R.id.refreshButt, color)
-        setImageViewColor(views, R.id.configButt, color)
-        setImageViewColor(views, R.id.divider, color)
-        views.setRemoteAdapter(R.id.card_list, getRemoteAdapterIntent(context, appWidgetId))
+
+        // Set up the card list
+        setImageViewColor(views, R.id.divider, cardFgColor)
         views.setEmptyView(R.id.card_list, R.id.empty_card_list)
-        views.setTextColor(R.id.empty_card_list, color)
-        setBackgroundColor(views, R.id.card_frame, bgcolor)
-        setBackgroundColor(views, R.id.title_bar, bgcolor)
+        views.setTextColor(R.id.empty_card_list, cardFgColor)
+        setBackgroundColor(views, R.id.card_frame, cardBgColor)
+        views.setPendingIntentTemplate(R.id.card_list, getCardPendingIntent(context))
+        views.setRemoteAdapter(R.id.card_list, getRemoteAdapterIntent(context, appWidgetId))
 
         appWidgetManager.updateAppWidget(appWidgetId, views)
     }

--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/widget/TrelloWidgetProvider.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/widget/TrelloWidgetProvider.kt
@@ -12,6 +12,7 @@ import com.github.oryanmat.trellowidget.R
 import com.github.oryanmat.trellowidget.activity.ConfigActivity
 import com.github.oryanmat.trellowidget.model.Board
 import com.github.oryanmat.trellowidget.util.*
+import com.github.oryanmat.trellowidget.util.RemoteViewsUtil.setBackgroundColor
 import com.github.oryanmat.trellowidget.util.RemoteViewsUtil.setImageViewColor
 import com.github.oryanmat.trellowidget.util.RemoteViewsUtil.setTextView
 
@@ -38,6 +39,7 @@ class TrelloWidgetProvider : AppWidgetProvider() {
         val list = context.getList(appWidgetId)
         val board = context.getBoard(appWidgetId)
         @ColorInt val color = context.getForegroundColor()
+        @ColorInt val bgcolor = context.getBackgroundColor()
 
         val views = RemoteViews(context.packageName, R.layout.trello_widget)
         setTextView(views, R.id.list_title, list.name, color)
@@ -51,7 +53,8 @@ class TrelloWidgetProvider : AppWidgetProvider() {
         views.setRemoteAdapter(R.id.card_list, getRemoteAdapterIntent(context, appWidgetId))
         views.setEmptyView(R.id.card_list, R.id.empty_card_list)
         views.setTextColor(R.id.empty_card_list, color)
-        setImageViewColor(views, R.id.background_image, context.getBackgroundColor())
+        setBackgroundColor(views, R.id.card_frame, bgcolor)
+        setBackgroundColor(views, R.id.title_bar, bgcolor)
 
         appWidgetManager.updateAppWidget(appWidgetId, views)
     }

--- a/app/src/main/res/drawable-mdpi/heading_divider.xml
+++ b/app/src/main/res/drawable-mdpi/heading_divider.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <size android:height="1dp" />
+    <solid android:color="#00ffffff" />
+</shape>

--- a/app/src/main/res/drawable/widget_background.xml
+++ b/app/src/main/res/drawable/widget_background.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="#000000" />
+    <solid android:color="#00000000" />
     <corners android:radius="2dp" />
 </shape>

--- a/app/src/main/res/layout/color_chooser.xml
+++ b/app/src/main/res/layout/color_chooser.xml
@@ -21,4 +21,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content" />
 
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/pref_title_copy_from_card"
+        android:id="@+id/copyButton" />
+
 </LinearLayout>

--- a/app/src/main/res/layout/trello_widget.xml
+++ b/app/src/main/res/layout/trello_widget.xml
@@ -18,7 +18,9 @@
 
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            android:id="@+id/title_bar"
+            android:background="#54ffffff">
 
             <TextView
                 android:id="@+id/list_title"
@@ -47,12 +49,13 @@
             android:id="@+id/divider"
             android:layout_width="match_parent"
             android:layout_height="1dp"
-            android:src="@drawable/divider"
+            android:src="@drawable/heading_divider"
             tools:ignore="ContentDescription" />
 
         <FrameLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:id="@+id/card_frame">
 
             <ListView
                 android:id="@+id/card_list"

--- a/app/src/main/res/values/strings_preferences.xml
+++ b/app/src/main/res/values/strings_preferences.xml
@@ -42,6 +42,8 @@
     <string name="pref_title_use_unique_color_disabled_desc">Enable to set a separate color for the widget title</string>
     <bool name="pref_title_use_unique_color_default">false</bool>
 
+    <string name="pref_title_copy_from_card">Copy from %s</string>
+
     <string name="pref_back_color_key">back_color</string>
     <string name="pref_back_color_title">List background</string>
     <string name="pref_back_color_desc">Change background color of the card list area</string>

--- a/app/src/main/res/values/strings_preferences.xml
+++ b/app/src/main/res/values/strings_preferences.xml
@@ -36,6 +36,12 @@
     <string name="pref_title_fore_color_desc">Change the text color of the title</string>
     <integer name="pref_title_fore_color_default">0xFFFFFFFF</integer>
 
+    <string name="pref_title_use_unique_color_key">title_use_unique_color</string>
+    <string name="pref_title_use_unique_color_title">Unique title color</string>
+    <string name="pref_title_use_unique_color_enabled_desc">Disable to use a single color for the entire widget</string>
+    <string name="pref_title_use_unique_color_disabled_desc">Enable to set a separate color for the widget title</string>
+    <bool name="pref_title_use_unique_color_default">false</bool>
+
     <string name="pref_back_color_key">back_color</string>
     <string name="pref_back_color_title">List background</string>
     <string name="pref_back_color_desc">Change background color of the card list area</string>

--- a/app/src/main/res/values/strings_preferences.xml
+++ b/app/src/main/res/values/strings_preferences.xml
@@ -26,14 +26,24 @@
         <item>1.75</item>
     </string-array>
 
+    <string name="pref_title_back_color_key">title_back_color</string>
+    <string name="pref_title_back_color_title">Title background</string>
+    <string name="pref_title_back_color_desc">Change background color of the title area</string>
+    <integer name="pref_title_back_color_default">0xDD000000</integer>
+
+    <string name="pref_title_fore_color_key">title_fore_color</string>
+    <string name="pref_title_fore_color_title">Title text color</string>
+    <string name="pref_title_fore_color_desc">Change the text color of the title</string>
+    <integer name="pref_title_fore_color_default">0xFFFFFFFF</integer>
+
     <string name="pref_back_color_key">back_color</string>
-    <string name="pref_back_color_title">Background color</string>
-    <string name="pref_back_color_desc">Change background color</string>
-    <integer name="pref_back_color_default">0xFF000000</integer>
+    <string name="pref_back_color_title">List background</string>
+    <string name="pref_back_color_desc">Change background color of the card list area</string>
+    <integer name="pref_back_color_default">0xAA000000</integer>
 
     <string name="pref_fore_color_key">fore_color</string>
-    <string name="pref_fore_color_title">Foreground color</string>
-    <string name="pref_fore_color_desc">Change foreground color</string>
+    <string name="pref_fore_color_title">List text color</string>
+    <string name="pref_fore_color_desc">Change the text color of the card list</string>
     <integer name="pref_fore_color_default">0xFFFFFFFF</integer>
 
     <string name="pref_update_interval_key">interval_list</string>

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -22,6 +22,12 @@
             android:summary="@string/pref_fore_color_desc"
             android:title="@string/pref_fore_color_title" />
 
+        <SwitchPreference
+            android:defaultValue="@bool/pref_title_use_unique_color_default"
+            android:key="@string/pref_title_use_unique_color_key"
+            android:summary="@string/pref_title_use_unique_color_disabled_desc"
+            android:title="@string/pref_title_use_unique_color_title" />
+
         <com.github.oryanmat.trellowidget.util.color.ColorPreference
             android:defaultValue="@integer/pref_title_back_color_default"
             android:key="@string/pref_title_back_color_key"

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -22,6 +22,18 @@
             android:summary="@string/pref_fore_color_desc"
             android:title="@string/pref_fore_color_title" />
 
+        <com.github.oryanmat.trellowidget.util.color.ColorPreference
+            android:defaultValue="@integer/pref_title_back_color_default"
+            android:key="@string/pref_title_back_color_key"
+            android:summary="@string/pref_title_back_color_desc"
+            android:title="@string/pref_title_back_color_title" />
+
+        <com.github.oryanmat.trellowidget.util.color.ColorPreference
+            android:defaultValue="@integer/pref_title_fore_color_default"
+            android:key="@string/pref_title_fore_color_key"
+            android:summary="@string/pref_title_fore_color_desc"
+            android:title="@string/pref_title_fore_color_title" />
+
         <ListPreference
             android:defaultValue="@string/pref_update_interval_default"
             android:entries="@array/pref_update_interval_titles"


### PR DESCRIPTION
This commit series splits the title of the widget from the card list area with a small transparent separator, and (optionally) allows setting the title background and foreground from the list background and foreground.

By default, I've made the title slightly less opaque than the list.  I think it looks good like that.  But users can now customize the look more if they like.

The color selectors for the title background and title foreground now have a new button that will copy in the color of the list background and list foreground, so it's easier to set the list background/foreground, copy them to the title, then tweak the title's opacity or saturation a bit.
