### PR TITLE
Lack/unique title background color

### DIFF
--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/activity/GeneralPreferenceFragment.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/activity/GeneralPreferenceFragment.kt
@@ -26,6 +26,13 @@ class GeneralPreferenceFragment : PreferenceFragment() {
         listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_title_fore_color_key))
         listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_title_use_unique_color_key))
         listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_update_interval_key))
+
+        val titleBgPref = findPreference(getString(R.string.pref_title_back_color_key)) as ColorPreference
+        val cardBgPref = findPreference(getString(R.string.pref_back_color_key)) as ColorPreference
+        titleBgPref.copyFrom = cardBgPref
+        val titleFgPref = findPreference(getString(R.string.pref_title_fore_color_key)) as ColorPreference
+        val cardFgPref = findPreference(getString(R.string.pref_fore_color_key)) as ColorPreference
+        titleFgPref.copyFrom = cardFgPref
     }
 
     override fun onResume() {

--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/activity/GeneralPreferenceFragment.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/activity/GeneralPreferenceFragment.kt
@@ -4,6 +4,7 @@ import android.content.SharedPreferences
 import android.os.Bundle
 import android.preference.ListPreference
 import android.preference.PreferenceFragment
+import android.preference.SwitchPreference
 import com.github.oryanmat.trellowidget.R
 import com.github.oryanmat.trellowidget.util.color.ColorPreference
 import com.github.oryanmat.trellowidget.widget.updateWidgets
@@ -23,6 +24,7 @@ class GeneralPreferenceFragment : PreferenceFragment() {
         listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_fore_color_key))
         listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_title_back_color_key))
         listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_title_fore_color_key))
+        listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_title_use_unique_color_key))
         listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_update_interval_key))
     }
 
@@ -60,6 +62,17 @@ class GeneralPreferenceFragment : PreferenceFragment() {
         } else if (key == getString(R.string.pref_title_fore_color_key)) {
             val preference = findPreference(key) as ColorPreference
             preference.summary = String.format(COLOR_FORMAT, preference.color)
+        } else if (key == getString(R.string.pref_title_use_unique_color_key)) {
+            val preference = findPreference(key) as SwitchPreference
+            with(preference) {
+                setSummary(if (isChecked)
+                    R.string.pref_title_use_unique_color_enabled_desc else
+                    R.string.pref_title_use_unique_color_disabled_desc)
+                val titleFgPref = findPreference(getString(R.string.pref_title_fore_color_key)) as ColorPreference
+                val titleBgPref = findPreference(getString(R.string.pref_title_back_color_key)) as ColorPreference
+                titleFgPref.isEnabled = isChecked
+                titleBgPref.isEnabled = isChecked
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/activity/GeneralPreferenceFragment.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/activity/GeneralPreferenceFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.preference.ListPreference
 import android.preference.PreferenceFragment
 import android.preference.SwitchPreference
+import android.support.annotation.IdRes
 import com.github.oryanmat.trellowidget.R
 import com.github.oryanmat.trellowidget.util.color.ColorPreference
 import com.github.oryanmat.trellowidget.widget.updateWidgets
@@ -27,12 +28,10 @@ class GeneralPreferenceFragment : PreferenceFragment() {
         listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_title_use_unique_color_key))
         listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_update_interval_key))
 
-        val titleBgPref = findPreference(getString(R.string.pref_title_back_color_key)) as ColorPreference
-        val cardBgPref = findPreference(getString(R.string.pref_back_color_key)) as ColorPreference
-        titleBgPref.copyFrom = cardBgPref
-        val titleFgPref = findPreference(getString(R.string.pref_title_fore_color_key)) as ColorPreference
-        val cardFgPref = findPreference(getString(R.string.pref_fore_color_key)) as ColorPreference
-        titleFgPref.copyFrom = cardFgPref
+        val titleBackgroundPref = colorPreference(R.string.pref_title_back_color_key)
+        titleBackgroundPref.copyData = colorPreference(R.string.pref_back_color_key).asColorData()
+        val titleForegroundPref = colorPreference(R.string.pref_title_fore_color_key)
+        titleForegroundPref.copyData = colorPreference(R.string.pref_fore_color_key).asColorData()
     }
 
     override fun onResume() {
@@ -72,14 +71,12 @@ class GeneralPreferenceFragment : PreferenceFragment() {
         } else if (key == getString(R.string.pref_title_use_unique_color_key)) {
             val preference = findPreference(key) as SwitchPreference
             with(preference) {
-                setSummary(if (isChecked)
-                    R.string.pref_title_use_unique_color_enabled_desc else
-                    R.string.pref_title_use_unique_color_disabled_desc)
-                val titleFgPref = findPreference(getString(R.string.pref_title_fore_color_key)) as ColorPreference
-                val titleBgPref = findPreference(getString(R.string.pref_title_back_color_key)) as ColorPreference
-                titleFgPref.isEnabled = isChecked
-                titleBgPref.isEnabled = isChecked
+                summary = getString(R.string.pref_title_use_unique_color_desc)
+                colorPreference(R.string.pref_title_fore_color_key).isEnabled = isChecked
+                colorPreference(R.string.pref_title_back_color_key).isEnabled = isChecked
             }
         }
     }
+
+    fun colorPreference(@IdRes key: Int) = findPreference(getString(key)) as ColorPreference
 }

--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/activity/GeneralPreferenceFragment.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/activity/GeneralPreferenceFragment.kt
@@ -21,6 +21,8 @@ class GeneralPreferenceFragment : PreferenceFragment() {
         listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_text_size_key))
         listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_back_color_key))
         listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_fore_color_key))
+        listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_title_back_color_key))
+        listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_title_fore_color_key))
         listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_update_interval_key))
     }
 
@@ -50,6 +52,12 @@ class GeneralPreferenceFragment : PreferenceFragment() {
             val preference = findPreference(key) as ColorPreference
             preference.summary = String.format(COLOR_FORMAT, preference.color)
         } else if (key == getString(R.string.pref_fore_color_key)) {
+            val preference = findPreference(key) as ColorPreference
+            preference.summary = String.format(COLOR_FORMAT, preference.color)
+        } else if (key == getString(R.string.pref_title_back_color_key)) {
+            val preference = findPreference(key) as ColorPreference
+            preference.summary = String.format(COLOR_FORMAT, preference.color)
+        } else if (key == getString(R.string.pref_title_fore_color_key)) {
             val preference = findPreference(key) as ColorPreference
             preference.summary = String.format(COLOR_FORMAT, preference.color)
         }

--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/PrefUtil.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/PrefUtil.kt
@@ -15,13 +15,21 @@ internal fun Context.getInterval() =
                 getString(R.string.pref_update_interval_key),
                 getString(R.string.pref_update_interval_default)))
 
-internal @ColorInt fun Context.getBackgroundColor() = getColor(
+internal @ColorInt fun Context.getCardBackgroundColor() = getColor(
         getString(R.string.pref_back_color_key),
         resources.getInteger(R.integer.pref_back_color_default))
 
-internal @ColorInt fun Context.getForegroundColor() = getColor(
+internal @ColorInt fun Context.getCardForegroundColor() = getColor(
         getString(R.string.pref_fore_color_key),
         resources.getInteger(R.integer.pref_fore_color_default))
+
+internal @ColorInt fun Context.getTitleBackgroundColor() = getColor(
+        getString(R.string.pref_back_color_key),
+        resources.getInteger(R.integer.pref_title_back_color_default))
+
+internal @ColorInt fun Context.getTitleForegroundColor() = getColor(
+        getString(R.string.pref_fore_color_key),
+        resources.getInteger(R.integer.pref_title_fore_color_default))
 
 private @ColorInt fun Context.getColor(key: String, defValue: Int) =
         sharedPreferences().getInt(key, defValue)

--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/PrefUtil.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/PrefUtil.kt
@@ -27,22 +27,18 @@ internal fun Context.isTitleUniqueColor() = sharedPreferences().getBoolean(
         getString(R.string.pref_title_use_unique_color_key),
         resources.getBoolean(R.bool.pref_title_use_unique_color_default))
 
-internal @ColorInt fun Context.getTitleBackgroundColor() : Int {
-    return if (isTitleUniqueColor())
-        getColor(
+internal @ColorInt fun Context.getTitleBackgroundColor(): Int = when {
+    isTitleUniqueColor() -> getColor(
             getString(R.string.pref_title_back_color_key),
             resources.getInteger(R.integer.pref_title_back_color_default))
-    else
-        getCardBackgroundColor()
+    else -> getCardBackgroundColor()
 }
 
-internal @ColorInt fun Context.getTitleForegroundColor() : Int {
-    return if (isTitleUniqueColor())
-        getColor(
+internal @ColorInt fun Context.getTitleForegroundColor(): Int = when {
+    isTitleUniqueColor() -> getColor(
             getString(R.string.pref_title_fore_color_key),
             resources.getInteger(R.integer.pref_title_fore_color_default))
-    else
-        getCardForegroundColor()
+    else -> getCardForegroundColor()
 }
 
 private @ColorInt fun Context.getColor(key: String, defValue: Int) =

--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/PrefUtil.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/PrefUtil.kt
@@ -23,13 +23,27 @@ internal @ColorInt fun Context.getCardForegroundColor() = getColor(
         getString(R.string.pref_fore_color_key),
         resources.getInteger(R.integer.pref_fore_color_default))
 
-internal @ColorInt fun Context.getTitleBackgroundColor() = getColor(
-        getString(R.string.pref_back_color_key),
-        resources.getInteger(R.integer.pref_title_back_color_default))
+internal fun Context.isTitleUniqueColor() = sharedPreferences().getBoolean(
+        getString(R.string.pref_title_use_unique_color_key),
+        resources.getBoolean(R.bool.pref_title_use_unique_color_default))
 
-internal @ColorInt fun Context.getTitleForegroundColor() = getColor(
-        getString(R.string.pref_fore_color_key),
-        resources.getInteger(R.integer.pref_title_fore_color_default))
+internal @ColorInt fun Context.getTitleBackgroundColor() : Int {
+    return if (isTitleUniqueColor())
+        getColor(
+            getString(R.string.pref_title_back_color_key),
+            resources.getInteger(R.integer.pref_title_back_color_default))
+    else
+        getCardBackgroundColor()
+}
+
+internal @ColorInt fun Context.getTitleForegroundColor() : Int {
+    return if (isTitleUniqueColor())
+        getColor(
+            getString(R.string.pref_title_fore_color_key),
+            resources.getInteger(R.integer.pref_title_fore_color_default))
+    else
+        getCardForegroundColor()
+}
 
 private @ColorInt fun Context.getColor(key: String, defValue: Int) =
         sharedPreferences().getInt(key, defValue)

--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/RemoteViewsUtil.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/RemoteViewsUtil.kt
@@ -16,6 +16,7 @@ import android.widget.RemoteViews
 object RemoteViewsUtil {
     val METHOD_SET_ALPHA = "setAlpha"
     val METHOD_SET_COLOR_FILTER = "setColorFilter"
+    val METHOD_SET_BACKGROUND = "setBackgroundColor"
     internal val IMAGE_SCALE = 1.5
 
     fun setTextView(context: Context, views: RemoteViews,
@@ -51,7 +52,7 @@ object RemoteViewsUtil {
     }
 
     fun setBackgroundColor(views: RemoteViews, @IdRes view: Int, @ColorInt color: Int) {
-        views.setInt(view, "setBackgroundColor", color)
+        views.setInt(view, METHOD_SET_BACKGROUND, color)
     }
 
     fun getScaledValue(context: Context, @DimenRes dimen: Int): Float {

--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/RemoteViewsUtil.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/RemoteViewsUtil.kt
@@ -50,6 +50,10 @@ object RemoteViewsUtil {
         views.setInt(view, METHOD_SET_ALPHA, alpha(color))
     }
 
+    fun setBackgroundColor(views: RemoteViews, @IdRes view: Int, @ColorInt color: Int) {
+        views.setInt(view, "setBackgroundColor", color)
+    }
+
     fun getScaledValue(context: Context, @DimenRes dimen: Int): Float {
         val dimension = context.resources.getDimension(dimen)
         val density = context.resources.displayMetrics.density

--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/TrelloAPIUtil.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/TrelloAPIUtil.kt
@@ -17,7 +17,7 @@ val TOKEN_PREF_KEY = "com.oryanmat.trellowidget.usertoken"
 val APP_KEY = "b250ef70ccf79ea5e107279a91045e6e"
 val BASE_URL = "https://api.trello.com/"
 val API_VERSION = "1/"
-val KEY = String.format("&key=%s", APP_KEY)
+val KEY = "&key=$APP_KEY"
 val AUTH_URL = "https://trello.com/1/authorize" +
         "?name=TrelloWidget" +
         KEY +

--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/color/ColorPreference.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/color/ColorPreference.kt
@@ -17,7 +17,8 @@ val DEFAULT_VALUE = Color.BLACK
  */
 class ColorPreference @JvmOverloads constructor(
         context: Context, attributeSet: AttributeSet,
-        var color: Int = DEFAULT_VALUE) : DialogPreference(context, attributeSet) {
+        var color: Int = DEFAULT_VALUE,
+        var copyFrom: ColorPreference? = null) : DialogPreference(context, attributeSet) {
 
     init {
         dialogLayoutResource = R.layout.color_chooser
@@ -41,6 +42,17 @@ class ColorPreference @JvmOverloads constructor(
             oldCenterColor = getPersistedInt(DEFAULT_VALUE)
             onColorChangedListener = ColorPicker.OnColorChangedListener { this@ColorPreference.color = it }
             repairSVBar(view, color)
+        }
+        with(view.copyButton) {
+            val copyTarget = copyFrom as? ColorPreference
+            visibility = if (copyTarget != null) View.VISIBLE else View.INVISIBLE
+            if (copyTarget is ColorPreference) {
+                text = context.getString(R.string.pref_title_copy_from_card, copyTarget.title)
+                setOnClickListener {
+                    view.color_picker.color = copyTarget.color
+                    repairSVBar(view, copyTarget.color)
+                }
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/color/ColorPreference.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/color/ColorPreference.kt
@@ -12,47 +12,41 @@ import kotlinx.android.synthetic.main.color_chooser.view.*
 
 val DEFAULT_VALUE = Color.BLACK
 
+data class ColorData(val title: CharSequence = "", val color: Int = 0)
+
 /**
  * a Preference class for colors (using a color picker) in the PreferenceFragments/Activities
  */
 class ColorPreference @JvmOverloads constructor(
         context: Context, attributeSet: AttributeSet,
         var color: Int = DEFAULT_VALUE,
-        var copyFrom: ColorPreference? = null) : DialogPreference(context, attributeSet) {
+        var copyData: ColorData = ColorData()) : DialogPreference(context, attributeSet) {
 
     init {
         dialogLayoutResource = R.layout.color_chooser
     }
 
-    fun repairSVBar(view: View, colorToFix: Int) {
-        // This is a work-around for a defect in holocolorpicker when using black with an SVBar
-        val hsv = FloatArray(3)
-        Color.colorToHSV(colorToFix, hsv)
-        if (hsv[1] == 0.0f && hsv[2] == 0.0f) {
-            view.svbar.setValue(hsv[2])
-        }
-    }
-
     override fun onBindDialogView(view: View) {
         super.onBindDialogView(view)
-        with(view.color_picker) {
-            addSVBar(view.svbar)
-            addOpacityBar(view.opacitybar)
-            color = getPersistedInt(DEFAULT_VALUE)
-            oldCenterColor = getPersistedInt(DEFAULT_VALUE)
-            onColorChangedListener = ColorPicker.OnColorChangedListener { this@ColorPreference.color = it }
-            repairSVBar(view, color)
-        }
-        with(view.copyButton) {
-            val copyTarget = copyFrom as? ColorPreference
-            visibility = if (copyTarget != null) View.VISIBLE else View.INVISIBLE
-            if (copyTarget is ColorPreference) {
-                text = context.getString(R.string.pref_title_copy_from_card, copyTarget.title)
-                setOnClickListener {
-                    view.color_picker.color = copyTarget.color
-                    repairSVBar(view, copyTarget.color)
-                }
-            }
+        initPicker(view)
+        initCopyButton(view)
+    }
+
+    private fun ColorPreference.initPicker(view: View) = with(view.color_picker) {
+        addSVBar(view.svbar)
+        addOpacityBar(view.opacitybar)
+        color = getPersistedInt(DEFAULT_VALUE)
+        oldCenterColor = getPersistedInt(DEFAULT_VALUE)
+        onColorChangedListener = ColorPicker.OnColorChangedListener { this@ColorPreference.color = it }
+        repairSVBar(view, color)
+    }
+
+    private fun ColorPreference.initCopyButton(view: View) = with(view.copyButton) {
+        visibility = if (copyData.title.isEmpty().not()) View.VISIBLE else View.GONE
+        text = context.getString(R.string.pref_title_copy_from_card, copyData.title)
+        setOnClickListener {
+            view.color_picker.color = copyData.color
+            repairSVBar(view, copyData.color)
         }
     }
 
@@ -71,7 +65,18 @@ class ColorPreference @JvmOverloads constructor(
         }
     }
 
-    override fun onGetDefaultValue(array: TypedArray, index: Int): Any {
-        return array.getInteger(index, DEFAULT_VALUE)
+    override fun onGetDefaultValue(array: TypedArray, index: Int): Any = array.getInteger(index, DEFAULT_VALUE)
+
+    fun asColorData() = ColorData(this.title, this.color)
+
+    /**
+     * This is a work-around for a defect in holocolorpicker when using black with an SVBar
+     */
+    fun repairSVBar(view: View, colorToFix: Int) {
+        val hsv = FloatArray(3)
+        Color.colorToHSV(colorToFix, hsv)
+        if (hsv[1] == 0.0f && hsv[2] == 0.0f) {
+            view.svbar.setValue(hsv[2])
+        }
     }
 }

--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/color/ColorUtil.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/color/ColorUtil.kt
@@ -3,18 +3,12 @@ package com.github.oryanmat.trellowidget.util.color
 import android.graphics.Color
 import android.support.annotation.ColorInt
 
-@ColorInt fun Int.dim(): Int {
+@ColorInt fun Int.dim(value: Float = .5f): Int {
     val hsv = FloatArray(3)
     Color.colorToHSV(this, hsv)
-    // half the value component
-    hsv[2] *= 0.5f
+    // set the value component
+    hsv[2] *= value
     return Color.HSVToColor(hsv)
 }
 
-@ColorInt fun Int.buttonDim(): Int {
-    val hsv = FloatArray(3)
-    Color.colorToHSV(this, hsv)
-    // 3/4 the value component
-    hsv[2] *= 0.75f
-    return Color.HSVToColor(hsv)
-}
+@ColorInt fun Int.lightDim(): Int = dim(.75f)

--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/color/ColorUtil.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/color/ColorUtil.kt
@@ -10,3 +10,11 @@ import android.support.annotation.ColorInt
     hsv[2] *= 0.5f
     return Color.HSVToColor(hsv)
 }
+
+@ColorInt fun Int.buttonDim(): Int {
+    val hsv = FloatArray(3)
+    Color.colorToHSV(this, hsv)
+    // 3/4 the value component
+    hsv[2] *= 0.75f
+    return Color.HSVToColor(hsv)
+}

--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/widget/CardRemoteViewFactory.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/widget/CardRemoteViewFactory.kt
@@ -22,7 +22,7 @@ import com.github.oryanmat.trellowidget.util.RemoteViewsUtil.setTextView
 import com.github.oryanmat.trellowidget.util.TrelloAPIUtil
 import com.github.oryanmat.trellowidget.util.color.colors
 import com.github.oryanmat.trellowidget.util.color.dim
-import com.github.oryanmat.trellowidget.util.getForegroundColor
+import com.github.oryanmat.trellowidget.util.getCardForegroundColor
 import com.github.oryanmat.trellowidget.util.getList
 import java.util.*
 
@@ -34,7 +34,7 @@ class CardRemoteViewFactory(private val context: Context,
     override fun onDataSetChanged() {
         var list = context.getList(appWidgetId)
         list = TrelloAPIUtil.instance.getCards(list)
-        color = context.getForegroundColor()
+        color = context.getCardForegroundColor()
 
         if (BoardList.ERROR != list.id) {
             cards = list.cards

--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/widget/TrelloWidgetProvider.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/widget/TrelloWidgetProvider.kt
@@ -15,6 +15,7 @@ import com.github.oryanmat.trellowidget.util.*
 import com.github.oryanmat.trellowidget.util.RemoteViewsUtil.setBackgroundColor
 import com.github.oryanmat.trellowidget.util.RemoteViewsUtil.setImageViewColor
 import com.github.oryanmat.trellowidget.util.RemoteViewsUtil.setTextView
+import com.github.oryanmat.trellowidget.util.color.buttonDim
 
 private val REFRESH_ACTION = "com.github.oryanmat.trellowidget.refreshAction"
 private val WIDGET_ID = "com.github.oryanmat.trellowidget.widgetId"
@@ -38,23 +39,29 @@ class TrelloWidgetProvider : AppWidgetProvider() {
         // TODO: We should update both the BoardList and Board on a refresh
         val list = context.getList(appWidgetId)
         val board = context.getBoard(appWidgetId)
-        @ColorInt val color = context.getForegroundColor()
-        @ColorInt val bgcolor = context.getBackgroundColor()
+        @ColorInt val cardFgColor = context.getCardForegroundColor()
+        @ColorInt val cardBgColor = context.getCardBackgroundColor()
+        @ColorInt val titleFgColor = context.getTitleForegroundColor()
+        @ColorInt val titleBgColor = context.getTitleBackgroundColor()
 
         val views = RemoteViews(context.packageName, R.layout.trello_widget)
-        setTextView(views, R.id.list_title, list.name, color)
+
+        // Set up the title bar
+        setTextView(views, R.id.list_title, list.name, titleFgColor)
+        setImageViewColor(views, R.id.refreshButt, titleFgColor.buttonDim())
+        setImageViewColor(views, R.id.configButt, titleFgColor.buttonDim())
+        setBackgroundColor(views, R.id.title_bar, titleBgColor)
         views.setOnClickPendingIntent(R.id.refreshButt, getRefreshPendingIntent(context, appWidgetId))
         views.setOnClickPendingIntent(R.id.configButt, getReconfigPendingIntent(context, appWidgetId))
         views.setOnClickPendingIntent(R.id.list_title, getTitleIntent(context, board))
-        views.setPendingIntentTemplate(R.id.card_list, getCardPendingIntent(context))
-        setImageViewColor(views, R.id.refreshButt, color)
-        setImageViewColor(views, R.id.configButt, color)
-        setImageViewColor(views, R.id.divider, color)
-        views.setRemoteAdapter(R.id.card_list, getRemoteAdapterIntent(context, appWidgetId))
+
+        // Set up the card list
+        setImageViewColor(views, R.id.divider, cardFgColor)
         views.setEmptyView(R.id.card_list, R.id.empty_card_list)
-        views.setTextColor(R.id.empty_card_list, color)
-        setBackgroundColor(views, R.id.card_frame, bgcolor)
-        setBackgroundColor(views, R.id.title_bar, bgcolor)
+        views.setTextColor(R.id.empty_card_list, cardFgColor)
+        setBackgroundColor(views, R.id.card_frame, cardBgColor)
+        views.setPendingIntentTemplate(R.id.card_list, getCardPendingIntent(context))
+        views.setRemoteAdapter(R.id.card_list, getRemoteAdapterIntent(context, appWidgetId))
 
         appWidgetManager.updateAppWidget(appWidgetId, views)
     }

--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/widget/TrelloWidgetProvider.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/widget/TrelloWidgetProvider.kt
@@ -15,7 +15,7 @@ import com.github.oryanmat.trellowidget.util.*
 import com.github.oryanmat.trellowidget.util.RemoteViewsUtil.setBackgroundColor
 import com.github.oryanmat.trellowidget.util.RemoteViewsUtil.setImageViewColor
 import com.github.oryanmat.trellowidget.util.RemoteViewsUtil.setTextView
-import com.github.oryanmat.trellowidget.util.color.buttonDim
+import com.github.oryanmat.trellowidget.util.color.lightDim
 
 private val REFRESH_ACTION = "com.github.oryanmat.trellowidget.refreshAction"
 private val WIDGET_ID = "com.github.oryanmat.trellowidget.widgetId"
@@ -37,33 +37,34 @@ class TrelloWidgetProvider : AppWidgetProvider() {
 
     private fun updateAppWidget(context: Context, appWidgetManager: AppWidgetManager, appWidgetId: Int) {
         // TODO: We should update both the BoardList and Board on a refresh
-        val list = context.getList(appWidgetId)
-        val board = context.getBoard(appWidgetId)
-        @ColorInt val cardFgColor = context.getCardForegroundColor()
-        @ColorInt val cardBgColor = context.getCardBackgroundColor()
-        @ColorInt val titleFgColor = context.getTitleForegroundColor()
-        @ColorInt val titleBgColor = context.getTitleBackgroundColor()
-
         val views = RemoteViews(context.packageName, R.layout.trello_widget)
+        updateTitleBar(appWidgetId, context, views)
+        updateCardList(appWidgetId, context, views)
+        appWidgetManager.updateAppWidget(appWidgetId, views)
+    }
 
-        // Set up the title bar
-        setTextView(views, R.id.list_title, list.name, titleFgColor)
-        setImageViewColor(views, R.id.refreshButt, titleFgColor.buttonDim())
-        setImageViewColor(views, R.id.configButt, titleFgColor.buttonDim())
-        setBackgroundColor(views, R.id.title_bar, titleBgColor)
+    private fun updateTitleBar(appWidgetId: Int, context: Context, views: RemoteViews) {
+        val board = context.getBoard(appWidgetId)
+        val list = context.getList(appWidgetId)
+        @ColorInt val foregroundColor = context.getTitleForegroundColor()
+
+        setBackgroundColor(views, R.id.title_bar, context.getTitleBackgroundColor())
+        setTextView(views, R.id.list_title, list.name, foregroundColor)
+        setImageViewColor(views, R.id.refreshButt, foregroundColor.lightDim())
+        setImageViewColor(views, R.id.configButt, foregroundColor.lightDim())
+        setBackgroundColor(views, R.id.divider, foregroundColor.lightDim())
+
+        views.setOnClickPendingIntent(R.id.list_title, getTitleIntent(context, board))
         views.setOnClickPendingIntent(R.id.refreshButt, getRefreshPendingIntent(context, appWidgetId))
         views.setOnClickPendingIntent(R.id.configButt, getReconfigPendingIntent(context, appWidgetId))
-        views.setOnClickPendingIntent(R.id.list_title, getTitleIntent(context, board))
+    }
 
-        // Set up the card list
-        setImageViewColor(views, R.id.divider, cardFgColor)
+    private fun updateCardList(appWidgetId: Int, context: Context, views: RemoteViews) {
+        setBackgroundColor(views, R.id.card_frame, context.getCardBackgroundColor())
+        views.setTextColor(R.id.empty_card_list, context.getCardForegroundColor())
         views.setEmptyView(R.id.card_list, R.id.empty_card_list)
-        views.setTextColor(R.id.empty_card_list, cardFgColor)
-        setBackgroundColor(views, R.id.card_frame, cardBgColor)
         views.setPendingIntentTemplate(R.id.card_list, getCardPendingIntent(context))
         views.setRemoteAdapter(R.id.card_list, getRemoteAdapterIntent(context, appWidgetId))
-
-        appWidgetManager.updateAppWidget(appWidgetId, views)
     }
 
     private fun getRemoteAdapterIntent(context: Context, appWidgetId: Int): Intent {

--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/widget/TrelloWidgetProvider.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/widget/TrelloWidgetProvider.kt
@@ -12,6 +12,7 @@ import com.github.oryanmat.trellowidget.R
 import com.github.oryanmat.trellowidget.activity.ConfigActivity
 import com.github.oryanmat.trellowidget.model.Board
 import com.github.oryanmat.trellowidget.util.*
+import com.github.oryanmat.trellowidget.util.RemoteViewsUtil.setBackgroundColor
 import com.github.oryanmat.trellowidget.util.RemoteViewsUtil.setImageViewColor
 import com.github.oryanmat.trellowidget.util.RemoteViewsUtil.setTextView
 
@@ -38,6 +39,7 @@ class TrelloWidgetProvider : AppWidgetProvider() {
         val list = context.getList(appWidgetId)
         val board = context.getBoard(appWidgetId)
         @ColorInt val color = context.getForegroundColor()
+        @ColorInt val bgcolor = context.getBackgroundColor()
 
         val views = RemoteViews(context.packageName, R.layout.trello_widget)
         setTextView(views, R.id.list_title, list.name, color)
@@ -51,7 +53,8 @@ class TrelloWidgetProvider : AppWidgetProvider() {
         views.setRemoteAdapter(R.id.card_list, getRemoteAdapterIntent(context, appWidgetId))
         views.setEmptyView(R.id.card_list, R.id.empty_card_list)
         views.setTextColor(R.id.empty_card_list, color)
-        setImageViewColor(views, R.id.background_image, context.getBackgroundColor())
+        setBackgroundColor(views, R.id.card_frame, bgcolor)
+        setBackgroundColor(views, R.id.title_bar, bgcolor)
 
         appWidgetManager.updateAppWidget(appWidgetId, views)
     }

--- a/app/src/main/res/drawable-mdpi/heading_divider.xml
+++ b/app/src/main/res/drawable-mdpi/heading_divider.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <size android:height="1dp" />
+    <solid android:color="#00ffffff" />
+</shape>

--- a/app/src/main/res/drawable-mdpi/heading_divider.xml
+++ b/app/src/main/res/drawable-mdpi/heading_divider.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <size android:height="1dp" />
-    <solid android:color="#00ffffff" />
-</shape>

--- a/app/src/main/res/drawable/widget_background.xml
+++ b/app/src/main/res/drawable/widget_background.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="#000000" />
+    <solid android:color="#00000000" />
     <corners android:radius="2dp" />
 </shape>

--- a/app/src/main/res/layout/color_chooser.xml
+++ b/app/src/main/res/layout/color_chooser.xml
@@ -21,4 +21,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content" />
 
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/pref_title_copy_from_card"
+        android:id="@+id/copyButton" />
+
 </LinearLayout>

--- a/app/src/main/res/layout/color_chooser.xml
+++ b/app/src/main/res/layout/color_chooser.xml
@@ -22,9 +22,10 @@
         android:layout_height="wrap_content" />
 
     <Button
+        android:id="@+id/copyButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/pref_title_copy_from_card"
-        android:id="@+id/copyButton" />
+        android:visibility="gone"/>
 
 </LinearLayout>

--- a/app/src/main/res/layout/trello_widget.xml
+++ b/app/src/main/res/layout/trello_widget.xml
@@ -18,7 +18,9 @@
 
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            android:id="@+id/title_bar"
+            android:background="#54ffffff">
 
             <TextView
                 android:id="@+id/list_title"
@@ -47,12 +49,13 @@
             android:id="@+id/divider"
             android:layout_width="match_parent"
             android:layout_height="1dp"
-            android:src="@drawable/divider"
+            android:src="@drawable/heading_divider"
             tools:ignore="ContentDescription" />
 
         <FrameLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:id="@+id/card_frame">
 
             <ListView
                 android:id="@+id/card_list"

--- a/app/src/main/res/layout/trello_widget.xml
+++ b/app/src/main/res/layout/trello_widget.xml
@@ -17,19 +17,19 @@
         android:orientation="vertical">
 
         <LinearLayout
+            android:id="@+id/title_bar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:id="@+id/title_bar"
             android:background="#54ffffff">
 
             <TextView
                 android:id="@+id/list_title"
                 style="@style/WidgetTitle"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:hint="@string/list_hint"
-                android:singleLine="true" />
+                android:maxLines="1" />
 
             <ImageButton
                 android:id="@+id/refreshButt"
@@ -49,13 +49,13 @@
             android:id="@+id/divider"
             android:layout_width="match_parent"
             android:layout_height="1dp"
-            android:src="@drawable/heading_divider"
+            android:src="@drawable/divider"
             tools:ignore="ContentDescription" />
 
         <FrameLayout
+            android:id="@+id/card_frame"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:id="@+id/card_frame">
+            android:layout_height="match_parent">
 
             <ListView
                 android:id="@+id/card_list"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,9 @@
     <string name="singed">Signed in as %s</string>
     <string name="logout">Logout</string>
 
+    <!-- color pref -->
+    <string name="pref_title_copy_from_card">Copy from %s</string>
+
     <!-- error -->
     <string name="http_fail">Trello http request failed: %s</string>
     <string name="login_fail">Login failed multiple times. Logging you out: %s</string>

--- a/app/src/main/res/values/strings_preferences.xml
+++ b/app/src/main/res/values/strings_preferences.xml
@@ -42,6 +42,8 @@
     <string name="pref_title_use_unique_color_disabled_desc">Enable to set a separate color for the widget title</string>
     <bool name="pref_title_use_unique_color_default">false</bool>
 
+    <string name="pref_title_copy_from_card">Copy from %s</string>
+
     <string name="pref_back_color_key">back_color</string>
     <string name="pref_back_color_title">List background</string>
     <string name="pref_back_color_desc">Change background color of the card list area</string>

--- a/app/src/main/res/values/strings_preferences.xml
+++ b/app/src/main/res/values/strings_preferences.xml
@@ -36,6 +36,12 @@
     <string name="pref_title_fore_color_desc">Change the text color of the title</string>
     <integer name="pref_title_fore_color_default">0xFFFFFFFF</integer>
 
+    <string name="pref_title_use_unique_color_key">title_use_unique_color</string>
+    <string name="pref_title_use_unique_color_title">Unique title color</string>
+    <string name="pref_title_use_unique_color_enabled_desc">Disable to use a single color for the entire widget</string>
+    <string name="pref_title_use_unique_color_disabled_desc">Enable to set a separate color for the widget title</string>
+    <bool name="pref_title_use_unique_color_default">false</bool>
+
     <string name="pref_back_color_key">back_color</string>
     <string name="pref_back_color_title">List background</string>
     <string name="pref_back_color_desc">Change background color of the card list area</string>

--- a/app/src/main/res/values/strings_preferences.xml
+++ b/app/src/main/res/values/strings_preferences.xml
@@ -26,14 +26,24 @@
         <item>1.75</item>
     </string-array>
 
+    <string name="pref_title_back_color_key">title_back_color</string>
+    <string name="pref_title_back_color_title">Title background</string>
+    <string name="pref_title_back_color_desc">Change background color of the title area</string>
+    <integer name="pref_title_back_color_default">0xDD000000</integer>
+
+    <string name="pref_title_fore_color_key">title_fore_color</string>
+    <string name="pref_title_fore_color_title">Title text color</string>
+    <string name="pref_title_fore_color_desc">Change the text color of the title</string>
+    <integer name="pref_title_fore_color_default">0xFFFFFFFF</integer>
+
     <string name="pref_back_color_key">back_color</string>
-    <string name="pref_back_color_title">Background color</string>
-    <string name="pref_back_color_desc">Change background color</string>
-    <integer name="pref_back_color_default">0xFF000000</integer>
+    <string name="pref_back_color_title">List background</string>
+    <string name="pref_back_color_desc">Change background color of the card list area</string>
+    <integer name="pref_back_color_default">0xAA000000</integer>
 
     <string name="pref_fore_color_key">fore_color</string>
-    <string name="pref_fore_color_title">Foreground color</string>
-    <string name="pref_fore_color_desc">Change foreground color</string>
+    <string name="pref_fore_color_title">List text color</string>
+    <string name="pref_fore_color_desc">Change the text color of the card list</string>
     <integer name="pref_fore_color_default">0xFFFFFFFF</integer>
 
     <string name="pref_update_interval_key">interval_list</string>

--- a/app/src/main/res/values/strings_preferences.xml
+++ b/app/src/main/res/values/strings_preferences.xml
@@ -28,31 +28,28 @@
 
     <string name="pref_title_back_color_key">title_back_color</string>
     <string name="pref_title_back_color_title">Title background</string>
-    <string name="pref_title_back_color_desc">Change background color of the title area</string>
+    <string name="pref_title_back_color_desc">Change the background color of the title</string>
     <integer name="pref_title_back_color_default">0xDD000000</integer>
 
     <string name="pref_title_fore_color_key">title_fore_color</string>
-    <string name="pref_title_fore_color_title">Title text color</string>
-    <string name="pref_title_fore_color_desc">Change the text color of the title</string>
+    <string name="pref_title_fore_color_title">Title foreground</string>
+    <string name="pref_title_fore_color_desc">Change the foreground color of the title</string>
     <integer name="pref_title_fore_color_default">0xFFFFFFFF</integer>
-
-    <string name="pref_title_use_unique_color_key">title_use_unique_color</string>
-    <string name="pref_title_use_unique_color_title">Unique title color</string>
-    <string name="pref_title_use_unique_color_enabled_desc">Disable to use a single color for the entire widget</string>
-    <string name="pref_title_use_unique_color_disabled_desc">Enable to set a separate color for the widget title</string>
-    <bool name="pref_title_use_unique_color_default">false</bool>
-
-    <string name="pref_title_copy_from_card">Copy from %s</string>
 
     <string name="pref_back_color_key">back_color</string>
     <string name="pref_back_color_title">List background</string>
-    <string name="pref_back_color_desc">Change background color of the card list area</string>
+    <string name="pref_back_color_desc">Change the background color of the card list</string>
     <integer name="pref_back_color_default">0xAA000000</integer>
 
     <string name="pref_fore_color_key">fore_color</string>
-    <string name="pref_fore_color_title">List text color</string>
-    <string name="pref_fore_color_desc">Change the text color of the card list</string>
+    <string name="pref_fore_color_title">List foreground</string>
+    <string name="pref_fore_color_desc">Change the foreground color of the card list</string>
     <integer name="pref_fore_color_default">0xFFFFFFFF</integer>
+
+    <string name="pref_title_use_unique_color_key">title_use_unique_color</string>
+    <string name="pref_title_use_unique_color_title">Unique title colors</string>
+    <string name="pref_title_use_unique_color_desc">Choose separate colors for the widget title</string>
+    <bool name="pref_title_use_unique_color_default">false</bool>
 
     <string name="pref_update_interval_key">interval_list</string>
     <string name="pref_update_interval_title">Refresh interval</string>

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -22,6 +22,12 @@
             android:summary="@string/pref_fore_color_desc"
             android:title="@string/pref_fore_color_title" />
 
+        <SwitchPreference
+            android:defaultValue="@bool/pref_title_use_unique_color_default"
+            android:key="@string/pref_title_use_unique_color_key"
+            android:summary="@string/pref_title_use_unique_color_disabled_desc"
+            android:title="@string/pref_title_use_unique_color_title" />
+
         <com.github.oryanmat.trellowidget.util.color.ColorPreference
             android:defaultValue="@integer/pref_title_back_color_default"
             android:key="@string/pref_title_back_color_key"

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -22,6 +22,18 @@
             android:summary="@string/pref_fore_color_desc"
             android:title="@string/pref_fore_color_title" />
 
+        <com.github.oryanmat.trellowidget.util.color.ColorPreference
+            android:defaultValue="@integer/pref_title_back_color_default"
+            android:key="@string/pref_title_back_color_key"
+            android:summary="@string/pref_title_back_color_desc"
+            android:title="@string/pref_title_back_color_title" />
+
+        <com.github.oryanmat.trellowidget.util.color.ColorPreference
+            android:defaultValue="@integer/pref_title_fore_color_default"
+            android:key="@string/pref_title_fore_color_key"
+            android:summary="@string/pref_title_fore_color_desc"
+            android:title="@string/pref_title_fore_color_title" />
+
         <ListPreference
             android:defaultValue="@string/pref_update_interval_default"
             android:entries="@array/pref_update_interval_titles"

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -25,7 +25,7 @@
         <SwitchPreference
             android:defaultValue="@bool/pref_title_use_unique_color_default"
             android:key="@string/pref_title_use_unique_color_key"
-            android:summary="@string/pref_title_use_unique_color_disabled_desc"
+            android:summary="@string/pref_title_use_unique_color_desc"
             android:title="@string/pref_title_use_unique_color_title" />
 
         <com.github.oryanmat.trellowidget.util.color.ColorPreference


### PR DESCRIPTION
copied from [pr](https://github.com/oryanm/TrelloWidget/pull/17)

> This commit series splits the title of the widget from the card list area with a small transparent 
> separator, and (optionally) allows setting the title background and foreground from the list background and foreground.
> 
> By default, I've made the title slightly less opaque than the list. I think it looks good like that. But users can now customize the look more if they like.
> 
> The color selectors for the title background and title foreground now have a new button that will copy in the color of the list background and list foreground, so it's easier to set the list background/foreground, copy them to the title, then tweak the title's opacity or saturation a bit.

plus some refactoring 