### PR TITLE
Add a layout that puts the board name and list name in the widget title

### DIFF
--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/activity/GeneralPreferenceFragment.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/activity/GeneralPreferenceFragment.kt
@@ -27,6 +27,7 @@ class GeneralPreferenceFragment : PreferenceFragment() {
         listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_title_fore_color_key))
         listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_title_use_unique_color_key))
         listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_update_interval_key))
+        listener.onSharedPreferenceChanged(preferences, getString(R.string.pref_two_line_title_key))
 
         val titleBackgroundPref = colorPreference(R.string.pref_title_back_color_key)
         titleBackgroundPref.copyData = colorPreference(R.string.pref_back_color_key).asColorData()
@@ -74,6 +75,14 @@ class GeneralPreferenceFragment : PreferenceFragment() {
                 summary = getString(R.string.pref_title_use_unique_color_desc)
                 colorPreference(R.string.pref_title_fore_color_key).isEnabled = isChecked
                 colorPreference(R.string.pref_title_back_color_key).isEnabled = isChecked
+            }
+        } else if (key == getString(R.string.pref_two_line_title_key)) {
+            val preference = findPreference(key) as SwitchPreference
+            with(preference) {
+                setSummary(if (isChecked)
+                    R.string.pref_two_line_title_enabled_desc else
+                    R.string.pref_two_line_title_disabled_desc
+                )
             }
         }
     }

--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/PrefUtil.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/PrefUtil.kt
@@ -23,6 +23,10 @@ internal @ColorInt fun Context.getCardForegroundColor() = getColor(
         getString(R.string.pref_fore_color_key),
         resources.getInteger(R.integer.pref_fore_color_default))
 
+internal fun Context.isTwoLineTitle() = sharedPreferences().getBoolean(
+        getString(R.string.pref_two_line_title_key),
+        resources.getBoolean(R.bool.pref_two_line_title_default))
+
 internal fun Context.isTitleUniqueColor() = sharedPreferences().getBoolean(
         getString(R.string.pref_title_use_unique_color_key),
         resources.getBoolean(R.bool.pref_title_use_unique_color_default))

--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/RemoteViewsUtil.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/util/RemoteViewsUtil.kt
@@ -11,6 +11,7 @@ import android.support.annotation.DrawableRes
 import android.support.annotation.IdRes
 import android.support.v4.content.ContextCompat
 import android.util.TypedValue
+import android.view.View
 import android.widget.RemoteViews
 
 object RemoteViewsUtil {
@@ -61,4 +62,13 @@ object RemoteViewsUtil {
         val prefTextScale = context.getPrefTextScale()
         return dimension * prefTextScale / density
     }
+
+    fun hideView(views: RemoteViews, @IdRes view: Int) {
+        views.setViewVisibility(view, View.GONE)
+    }
+
+    fun showView(views: RemoteViews, @IdRes view: Int) {
+        views.setViewVisibility(view, View.VISIBLE)
+    }
+
 }

--- a/app/src/main/kotlin/com/github/oryanmat/trellowidget/widget/TrelloWidgetProvider.kt
+++ b/app/src/main/kotlin/com/github/oryanmat/trellowidget/widget/TrelloWidgetProvider.kt
@@ -16,6 +16,8 @@ import com.github.oryanmat.trellowidget.util.RemoteViewsUtil.setBackgroundColor
 import com.github.oryanmat.trellowidget.util.RemoteViewsUtil.setImageViewColor
 import com.github.oryanmat.trellowidget.util.RemoteViewsUtil.setTextView
 import com.github.oryanmat.trellowidget.util.color.lightDim
+import com.github.oryanmat.trellowidget.util.RemoteViewsUtil.showView
+import com.github.oryanmat.trellowidget.util.RemoteViewsUtil.hideView
 
 private val REFRESH_ACTION = "com.github.oryanmat.trellowidget.refreshAction"
 private val WIDGET_ID = "com.github.oryanmat.trellowidget.widgetId"
@@ -48,13 +50,22 @@ class TrelloWidgetProvider : AppWidgetProvider() {
         val list = context.getList(appWidgetId)
         @ColorInt val foregroundColor = context.getTitleForegroundColor()
 
-        setBackgroundColor(views, R.id.title_bar, context.getTitleBackgroundColor())
-        setTextView(views, R.id.list_title, list.name, foregroundColor)
+        // Set up the title bar
+        if (context.isTwoLineTitle() && board.id != "-1") {
+            showView(views, R.id.two_line_title)
+            setTextView(views, R.id.board_title, board.name, foregroundColor)
+            setTextView(views, R.id.list_subtitle, list.name, foregroundColor)
+            hideView(views, R.id.list_title)
+            views.setOnClickPendingIntent(R.id.two_line_title, getTitleIntent(context, board))
+        } else {
+            showView(views, R.id.list_title)
+            setTextView(views, R.id.list_title, list.name, foregroundColor)
+            hideView(views, R.id.two_line_title)
+            views.setOnClickPendingIntent(R.id.list_title, getTitleIntent(context, board))
+        }
         setImageViewColor(views, R.id.refreshButt, foregroundColor.lightDim())
         setImageViewColor(views, R.id.configButt, foregroundColor.lightDim())
-        setImageViewColor(views, R.id.divider, foregroundColor)
-
-        views.setOnClickPendingIntent(R.id.list_title, getTitleIntent(context, board))
+        setBackgroundColor(views, R.id.title_bar, context.getTitleBackgroundColor())
         views.setOnClickPendingIntent(R.id.refreshButt, getRefreshPendingIntent(context, appWidgetId))
         views.setOnClickPendingIntent(R.id.configButt, getReconfigPendingIntent(context, appWidgetId))
     }

--- a/app/src/main/res/layout/trello_widget.xml
+++ b/app/src/main/res/layout/trello_widget.xml
@@ -22,14 +22,45 @@
             android:layout_height="wrap_content"
             android:background="#54ffffff">
 
-            <TextView
-                android:id="@+id/list_title"
-                style="@style/WidgetTitle"
+            <FrameLayout
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
-                android:hint="@string/list_hint"
-                android:maxLines="1" />
+                android:id="@+id/widget_title">
+
+                <LinearLayout
+                    android:orientation="vertical"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    style="@style/WidgetTitle"
+                    android:id="@+id/two_line_title">
+
+                    <TextView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="@string/board_hint"
+                        android:id="@+id/board_title"
+                        android:maxLines="1"
+                        style="@style/BoardTitle" />
+
+                    <TextView
+                        android:id="@+id/list_subtitle"
+                        style="@style/ListSubtitle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="@string/list_hint"
+                        android:maxLines="1"
+                        android:layout_marginTop="-3dp" />
+                </LinearLayout>
+
+                 <TextView
+                     android:id="@+id/list_title"
+                     style="@style/ListTitle"
+                     android:layout_width="match_parent"
+                     android:layout_height="match_parent"
+                     android:hint="@string/list_hint"
+                     android:maxLines="1" />
+            </FrameLayout>
 
             <ImageButton
                 android:id="@+id/refreshButt"
@@ -71,5 +102,6 @@
                 android:text="@string/no_cards"
                 android:textAppearance="?android:attr/textAppearanceMedium" />
         </FrameLayout>
+
     </LinearLayout>
 </FrameLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -6,7 +6,9 @@
     <!-- widget-->
     <dimen name="widget_margin">8dp</dimen>
 
-    <dimen name="title_padding">4dp</dimen>
+    <dimen name="left_title_padding">4dp</dimen>
+    <dimen name="title_padding">2dp</dimen>
+    <dimen name="list_title_padding">3dp</dimen>
     <dimen name="card_padding_bottom">4dp</dimen>
     <dimen name="card_padding_top">2dp</dimen>
     <dimen name="card_badge_padding">2dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="title_activity_card">Card Details</string>
 
     <!-- widget -->
+    <string name="board_hint">Board name</string>
     <string name="list_hint">List name</string>
     <string name="no_cards">No more cards!</string>
     <string name="refresh">Refresh list cards</string>

--- a/app/src/main/res/values/strings_preferences.xml
+++ b/app/src/main/res/values/strings_preferences.xml
@@ -57,6 +57,12 @@
     <string name="pref_update_interval_value_desc">Refresh lists every %s</string>
     <string name="pref_update_interval_default">900000</string>
 
+    <string name="pref_two_line_title_key">two_line_key</string>
+    <string name="pref_two_line_title_title">Two-line title</string>
+    <string name="pref_two_line_title_enabled_desc">Disable to have only the list name as the widget title</string>
+    <string name="pref_two_line_title_disabled_desc">Enable to have the board and list names in the widget title</string>
+    <bool name="pref_two_line_title_default">true</bool>
+
     <string-array name="pref_update_interval_titles">
         <item>15 minuets</item>
         <item>half hour</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -3,14 +3,30 @@
     <style name="AppTheme" parent="android:Theme.DeviceDefault" />
 
     <style name="WidgetTitle">
-        <item name="android:layout_width">fill_parent</item>
-        <item name="android:layout_height">wrap_content</item>
+        <item name="android:paddingTop">@dimen/title_padding</item>
+        <item name="android:paddingBottom">@dimen/title_padding</item>
+        <item name="android:paddingLeft">@dimen/left_title_padding</item>
+    </style>
+
+    <style name="BoardTitle">
+        <item name="android:textColor">#ffffff</item>
+        <item name="android:textStyle">normal</item>
+        <item name="android:textSize">10sp</item>
+    </style>
+
+    <style name="ListSubtitle">
+        <item name="android:textColor">#ffffff</item>
+        <item name="android:textSize">14sp</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+
+    <style name="ListTitle">
+        <item name="android:paddingTop">@dimen/list_title_padding</item>
+        <item name="android:paddingBottom">@dimen/list_title_padding</item>
+        <item name="android:paddingLeft">@dimen/left_title_padding</item>
         <item name="android:textColor">#ffffff</item>
         <item name="android:textStyle">bold</item>
         <item name="android:textSize">20sp</item>
-        <item name="android:paddingTop">@dimen/title_padding</item>
-        <item name="android:paddingBottom">@dimen/title_padding</item>
-        <item name="android:paddingLeft">@dimen/title_padding</item>
     </style>
 
     <style name="WidgetItemBadge">

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -10,6 +10,12 @@
             android:summary="@string/pref_text_size_desc"
             android:title="@string/pref_text_size_title" />
 
+        <SwitchPreference
+            android:defaultValue="@bool/pref_two_line_title_default"
+            android:key="@string/pref_two_line_title_key"
+            android:summary="@string/pref_two_line_title_enabled_desc"
+            android:title="@string/pref_two_line_title_title" />
+
         <com.github.oryanmat.trellowidget.util.color.ColorPreference
             android:defaultValue="@integer/pref_back_color_default"
             android:key="@string/pref_back_color_key"


### PR DESCRIPTION
This is configurable via a global preference.

Signed-off-by: Jim Ramsay <i.am@jimramsay.com>